### PR TITLE
Update caching to normalize email keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ $ npm install
 
 Use `SDK_CACHE_TTL_MS` to control how long SDK instances stay cached.
 The default is one hour (3600000ms).
+Emails are normalized to lowercase before caching so each address stores only one SDK instance.
 
 ## Compile and run the project
 


### PR DESCRIPTION
## Summary
- enforce lowercase normalized emails when caching SDK instances
- document email normalization in README

## Testing
- `npm test` *(fails: Cannot find module './app.controller.js')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847b4d326708331a62f626b888bf065