### PR TITLE
Allow custom digital option period

### DIFF
--- a/src/trading/digital/digital.service.ts
+++ b/src/trading/digital/digital.service.ts
@@ -1,16 +1,19 @@
-import { Injectable, Logger, NotFoundException, BadRequestException, InternalServerErrorException } from '@nestjs/common';
-import type { ClientSdk as ClientSdkType, Balance as BalanceSdkType } from '@quadcode-tech/client-sdk-js';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import type { ClientSdk as ClientSdkType } from '@quadcode-tech/client-sdk-js';
 import { mapTradeDirection } from '../utils/map-direction.util.js';
 import { BuyDigitalDto } from './dto/buy-digital.dto.js';
 import { AccountType as AppAccountType } from '../../shared/enums/account-type.enum.js';
-import { TradeDirection } from '../../shared/enums/direction.enum.js';
 
 @Injectable()
 export class DigitalService {
   private readonly logger = new Logger(DigitalService.name);
   private readonly preloadMap = new WeakMap<ClientSdkType, Promise<void>>();
-
-  private static readonly OPTION_PERIOD = 60;
 
 
   private async ensurePreloaded(sdk: ClientSdkType): Promise<void> {
@@ -25,30 +28,49 @@ export class DigitalService {
   private async preloadDigitalOptions(sdk: ClientSdkType): Promise<void> {
     try {
       const digitalOptions = await sdk.digitalOptions();
-      const underlyings = digitalOptions.getUnderlyingsAvailableForTradingAt(new Date());
+      const underlyings = digitalOptions.getUnderlyingsAvailableForTradingAt(
+        new Date(),
+      );
       await Promise.all(
-        underlyings.map(async underlying => {
+        underlyings.map(async (underlying) => {
           try {
             await underlying.instruments();
           } catch (error) {
-            this.logger.warn(`Failed to preload instruments for ${underlying.name}: ${error instanceof Error ? error.message : String(error)}`);
+            this.logger.warn(
+              `Failed to preload instruments for ${underlying.name}: ${error instanceof Error ? error.message : String(error)}`,
+            );
           }
         }),
       );
     } catch (error) {
-      this.logger.warn(`Failed to preload digital options cache: ${error instanceof Error ? error.message : String(error)}`);
+      this.logger.warn(
+        `Failed to preload digital options cache: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 
+  async buyOption(
+    sdk: ClientSdkType,
+    buyDigitalDto: BuyDigitalDto,
+  ): Promise<any> {
+    const {
+      assetName,
+      operationValue,
+      direction,
+      account_type,
+      option_period,
+    } = buyDigitalDto;
 
-  async buyOption(sdk: ClientSdkType, buyDigitalDto: BuyDigitalDto): Promise<any> {
-    const { assetName, operationValue, direction, account_type } = buyDigitalDto;
+    const period = option_period;
 
-    this.logger.log(`Attempting to buy digital option for asset "${assetName}", value: ${operationValue}, direction: ${direction}, account: ${account_type}`);
+    this.logger.log(
+      `Attempting to buy digital option for asset "${assetName}", value: ${operationValue}, direction: ${direction}, account: ${account_type}, period: ${period}`,
+    );
 
     try {
-
-      const { BalanceType, DigitalOptionsDirection } = await import('@quadcode-tech/client-sdk-js');
+      const { BalanceType, DigitalOptionsDirection } = await import(
+        '@quadcode-tech/client-sdk-js'
+      );
 
       await this.ensurePreloaded(sdk);
 
@@ -59,38 +81,61 @@ export class DigitalService {
 
       const availableUnderlying = digitalOptions
         .getUnderlyingsAvailableForTradingAt(new Date())
-        .find(item => !item.isSuspended && item.name === assetName);
+        .find((item) => !item.isSuspended && item.name === assetName);
 
       if (!availableUnderlying) {
-        this.logger.warn(`Digital asset "${assetName}" not available for trading.`);
-        throw new NotFoundException(`Ativo digital "${assetName}" não disponível para trading`);
+        this.logger.warn(
+          `Digital asset "${assetName}" not available for trading.`,
+        );
+        throw new NotFoundException(
+          `Ativo digital "${assetName}" não disponível para trading`,
+        );
       }
 
       const instruments = await availableUnderlying.instruments();
       const availableInstrument = instruments
         .getAvailableForBuyAt(new Date())
 
-        .find(instrument => instrument.period === DigitalService.OPTION_PERIOD);
+        .find((instrument) => instrument.period === period);
 
       if (!availableInstrument) {
-        this.logger.warn(`Instrument (period 60s) for digital asset "${assetName}" not found.`);
-        throw new NotFoundException(`Instrumento (período 60s) para o ativo "${assetName}" não encontrado`);
+        this.logger.warn(
+          `Instrument (period ${period}s) for digital asset "${assetName}" not found.`,
+        );
+        throw new NotFoundException(
+          `Instrumento (período ${period}s) para o ativo "${assetName}" não encontrado`,
+        );
       }
 
-      const sdkBalanceType = account_type === AppAccountType.Real ? BalanceType.Real : BalanceType.Demo;
-      const balance = balancesInstance.getBalances().find(b => b.type === sdkBalanceType);
+      const sdkBalanceType =
+        account_type === AppAccountType.Real
+          ? BalanceType.Real
+          : BalanceType.Demo;
+      const balance = balancesInstance
+        .getBalances()
+        .find((b) => b.type === sdkBalanceType);
 
       if (!balance) {
         this.logger.warn(`Balance type "${account_type}" not found.`);
         throw new NotFoundException(`Saldo "${account_type}" não encontrado`);
       }
 
-      if (typeof balance.available !== 'number' || balance.available < operationValue) {
-        this.logger.warn(`Insufficient balance. Available: ${balance.available}, Needed: ${operationValue}`);
-        throw new BadRequestException(`Saldo insuficiente para a operação. Disponível: ${balance.available}, Necessário: ${operationValue}`);
+      if (
+        typeof balance.available !== 'number' ||
+        balance.available < operationValue
+      ) {
+        this.logger.warn(
+          `Insufficient balance. Available: ${balance.available}, Needed: ${operationValue}`,
+        );
+        throw new BadRequestException(
+          `Saldo insuficiente para a operação. Disponível: ${balance.available}, Necessário: ${operationValue}`,
+        );
       }
 
-      const sdkDirection = mapTradeDirection(direction, DigitalOptionsDirection);
+      const sdkDirection = mapTradeDirection(
+        direction,
+        DigitalOptionsDirection,
+      );
 
       //this.logger.log(`Placing digital option order for instrument ID: ${availableInstrument.assetId}, direction: ${sdkDirection}`);
       const order = await digitalOptions.buySpotStrike(
@@ -100,15 +145,25 @@ export class DigitalService {
         balance,
       );
 
-      this.logger.log(`Digital option purchased successfully. Order ID (example): ${order.id || 'N/A'}`);
+      this.logger.log(
+        `Digital option purchased successfully. Order ID (example): ${order.id || 'N/A'}`,
+      );
       return order;
     } catch (error) {
-      this.logger.error(`Error buying digital option for asset "${assetName}": ${error.message}`, error.stack);
-      if (error instanceof NotFoundException || error instanceof BadRequestException) {
+      this.logger.error(
+        `Error buying digital option for asset "${assetName}": ${error.message}`,
+        error.stack,
+      );
+      if (
+        error instanceof NotFoundException ||
+        error instanceof BadRequestException
+      ) {
         throw error;
       }
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new InternalServerErrorException(`Erro ao comprar opção digital: ${errorMessage}`);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new InternalServerErrorException(
+        `Erro ao comprar opção digital: ${errorMessage}`,
+      );
     }
-  }
-}
+  }}

--- a/src/trading/digital/dto/buy-digital.dto.ts
+++ b/src/trading/digital/dto/buy-digital.dto.ts
@@ -1,3 +1,10 @@
 import { BaseTradeDto } from '../../dto/base-trade.dto.js';
-
-export class BuyDigitalDto extends BaseTradeDto {}
+import { IsNumber, IsPositive, IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+export class BuyDigitalDto extends BaseTradeDto {
+  @IsNumber({}, { message: 'option_period deve ser um número' })
+  @IsPositive({ message: 'option_period deve ser um número positivo' })
+  @IsNotEmpty({ message: 'option_period é obrigatório' })
+  @Type(() => Number)
+  option_period: number;
+}


### PR DESCRIPTION
## Summary
- enable specifying the period for digital options via a required request parameter
- enforce validation for the new `option_period` field

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test` *(fails: Cannot find module './app.controller.js')*

------
https://chatgpt.com/codex/tasks/task_e_686dcdbde59c833181de523fc43a0c43