### PR TITLE
Add logging interceptor and controller logs

### DIFF
--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, HttpStatus, Logger } from '@nestjs/common';
 import { AccountService } from './account.service.js';
 import { GetBalanceDto } from './dto/get-balance.dto.js';
 import { SdkService } from '../sdk/sdk.service.js';
@@ -10,11 +10,15 @@ export class AccountController {
     private readonly sdkService: SdkService,
   ) {}
 
-  @Post('balance') 
+  private readonly logger = new Logger(AccountController.name);
+
+  @Post('balance')
   @HttpCode(HttpStatus.OK)
   async getBalances(@Body() getBalanceDto: GetBalanceDto) {
+    this.logger.log(`POST /account/balance - email: ${getBalanceDto.email}`);
     const sdk = await this.sdkService.getSdk(getBalanceDto.email, getBalanceDto.password);
     const balances = await this.accountService.getAccountBalances(sdk);
+    this.logger.log(`Retrieved ${balances.length} balances for ${getBalanceDto.email}`);
     return { balances };
   }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,17 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Logger } from '@nestjs/common';
 import { AppService } from './app.service.js';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
+  private readonly logger = new Logger(AppController.name);
+
   @Get()
   getHello(): string {
-    return this.appService.getHello();
+    this.logger.log('GET /');
+    const greeting = this.appService.getHello();
+    this.logger.log('Responding with greeting');
+    return greeting;
   }
 }

--- a/src/logging.interceptor.ts
+++ b/src/logging.interceptor.ts
@@ -1,0 +1,33 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler, Logger } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  private readonly logger = new Logger('HTTP');
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const req = context.switchToHttp().getRequest();
+    const { method, url } = req;
+    const now = Date.now();
+    this.logger.log(`Request: ${method} ${url}`);
+
+    return next.handle().pipe(
+      tap(() => {
+        const res = context.switchToHttp().getResponse();
+        const status = res?.statusCode;
+        const delay = Date.now() - now;
+        this.logger.log(`Response: ${method} ${url} ${status} +${delay}ms`);
+      }),
+      catchError((err) => {
+        const res = context.switchToHttp().getResponse();
+        const status = res?.statusCode;
+        const delay = Date.now() - now;
+        this.logger.error(
+          `Error: ${method} ${url} ${status} +${delay}ms - ${err instanceof Error ? err.message : err}`,
+        );
+        throw err;
+      }),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { ValidationPipe, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import compress from '@fastify/compress';
+import { LoggingInterceptor } from './logging.interceptor.js';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -14,6 +15,8 @@ async function bootstrap() {
   const configService = app.get(ConfigService);
   const port = configService.get<number>('PORT', 3000);
   const nodeEnv = configService.get<string>('NODE_ENV', 'development');
+
+  app.useGlobalInterceptors(new LoggingInterceptor());
 
   app.setGlobalPrefix('api');
   app.enableCors();

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Query, HttpCode, HttpStatus, Logger } from '@nestjs/common';
 import { OrderService } from './order.service.js';
 import { GetOrderQueryDto } from './dto/get-order.dto.js';
 import { SdkService } from '../sdk/sdk.service.js';
@@ -11,20 +11,24 @@ export class OrderController {
     private readonly sdkService: SdkService,
   ) {}
 
+  private readonly logger = new Logger(OrderController.name);
+
   @Get() // Route will be /api/order?email=...&password=...&orderId=...
   @HttpCode(HttpStatus.OK)
   async getOrder(@Query() getOrderDto: GetOrderQueryDto) {
+    this.logger.log(`GET /order - email: ${getOrderDto.email}, orderId: ${getOrderDto.orderId}`);
     const sdk = await this.sdkService.getSdk(getOrderDto.email, getOrderDto.password);
     const orderId = Number(getOrderDto.orderId);
     const orderDetails = await this.orderService.getOrderDetails(sdk, getOrderDto.email,orderId, getOrderDto.uniqueId);
-    return orderDetails; 
+    this.logger.log(`Fetched order details for ${getOrderDto.email} - ${orderId}`);
+    return orderDetails;
   }
   @Get('history') // Route will be /api/order/history?email=...&password=...&activeId=...
   @HttpCode(HttpStatus.OK)
   async getOrderHistory(@Query() getOrderDto: GetHistoryDto) {
-    
-    
+    this.logger.log(`GET /order/history - email: ${getOrderDto.email}`);
     const orderHistory = await this.orderService.getOrderHistory(getOrderDto.email);
-    return orderHistory; 
+    this.logger.log(`Retrieved order history for ${getOrderDto.email}`);
+    return orderHistory;
   }
 }

--- a/src/trading/digital/digital.controller.ts
+++ b/src/trading/digital/digital.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, HttpStatus, Logger } from '@nestjs/common';
 import { DigitalService } from './digital.service.js';
 import { BuyDigitalDto } from './dto/buy-digital.dto.js';
 import { SdkService } from '../../sdk/sdk.service.js';
@@ -10,11 +10,15 @@ export class DigitalController {
     private readonly sdkService: SdkService,
   ) {}
 
+  private readonly logger = new Logger(DigitalController.name);
+
   @Post('buy')
   @HttpCode(HttpStatus.CREATED)
   async buyDigitalOption(@Body() buyDigitalDto: BuyDigitalDto) {
+    this.logger.log(`POST /trade/digital/buy - email: ${buyDigitalDto.email}`);
     const sdk = await this.sdkService.getSdk(buyDigitalDto.email, buyDigitalDto.password);
     const order = await this.digitalService.buyOption(sdk, buyDigitalDto);
+    this.logger.log(`Digital option order placed for ${buyDigitalDto.email}`);
     return { message: 'Digital option purchase initiated.', order };
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post, Logger } from '@nestjs/common';
 import { UserService } from './user.service.js';
 import { RegisterUserDto } from './dto/register-user.dto.js';
 
@@ -6,10 +6,14 @@ import { RegisterUserDto } from './dto/register-user.dto.js';
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
+  private readonly logger = new Logger(UserController.name);
+
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
   async register(@Body() dto: RegisterUserDto) {
+    this.logger.log(`POST /user/register - identifier: ${dto.identifier}`);
     const result = await this.userService.registerUser(dto);
+    this.logger.log(`User registration completed for ${dto.identifier}`);
     return result;
   }
 }

--- a/src/webhook/webhook.controller.ts
+++ b/src/webhook/webhook.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post, Logger } from '@nestjs/common';
 import { EventsGateway } from '../websocket/events.gateway.js';
 import { TradeWebhookDto } from './dto/trade-webhook.dto.js';
 
@@ -6,10 +6,14 @@ import { TradeWebhookDto } from './dto/trade-webhook.dto.js';
 export class WebhookController {
   constructor(private readonly gateway: EventsGateway) {}
 
+  private readonly logger = new Logger(WebhookController.name);
+
   @Post('trade')
   @HttpCode(HttpStatus.OK)
   handleTrade(@Body() dto: TradeWebhookDto) {
+    this.logger.log('POST /webhook/trade');
     this.gateway.emitTrade(dto);
+    this.logger.log('Trade event emitted to WebSocket clients');
     return { message: 'received' };
   }
 }

--- a/src/websocket/events.gateway.ts
+++ b/src/websocket/events.gateway.ts
@@ -1,4 +1,5 @@
 import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Logger } from '@nestjs/common';
 import { Server } from 'socket.io';
 
 @WebSocketGateway({ cors: true })
@@ -6,7 +7,10 @@ export class EventsGateway {
   @WebSocketServer()
   server!: Server;
 
+  private readonly logger = new Logger(EventsGateway.name);
+
   emitTrade(data: unknown): void {
+    this.logger.log('Emitting trade event via WebSocket');
     this.server.emit('trade', data);
   }
 }


### PR DESCRIPTION
## Summary
- add a global `LoggingInterceptor` to log requests, responses and errors
- register the interceptor in the bootstrap function
- log key actions within controllers and websocket gateway

## Testing
- `npm test` *(fails: Cannot find module './app.controller.js')*

------
https://chatgpt.com/codex/tasks/task_e_6883d727562c8331bbf95bd367ea33ae