### PR TITLE
feat: add candle route, binary trading, and dynamic order collections

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { WebhookModule } from './webhook/webhook.module.js';
 import { WebsocketModule } from './websocket/websocket.module.js';
 import { ConfigService } from '@nestjs/config';
 import { UserModule } from './user/user.module.js';
+import { CandlesModule } from './candles/candles.module.js';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { UserModule } from './user/user.module.js';
     WebhookModule,
     WebsocketModule,
     UserModule,
+    CandlesModule,
   ],
   controllers: [AppController],
   providers: [Logger, AppService]

--- a/src/candles/candles.controller.ts
+++ b/src/candles/candles.controller.ts
@@ -1,0 +1,31 @@
+import {
+  Controller,
+  Get,
+  Query,
+  HttpCode,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { CandlesService } from './candles.service.js';
+import { GetCandlesDto } from './dto/get-candles.dto.js';
+import { SdkService } from '../sdk/sdk.service.js';
+
+@Controller('candles')
+export class CandlesController {
+  constructor(
+    private readonly candlesService: CandlesService,
+    private readonly sdkService: SdkService,
+  ) {}
+
+  private readonly logger = new Logger(CandlesController.name);
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getCandles(@Query() query: GetCandlesDto) {
+    this.logger.log(
+      `GET /candles - email: ${query.email}, pair: ${query.pair}`,
+    );
+    const sdk = await this.sdkService.getSdk(query.email, query.password);
+    return this.candlesService.getCandles(sdk, query.pair, query.period);
+  }
+}

--- a/src/candles/candles.module.ts
+++ b/src/candles/candles.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CandlesController } from './candles.controller.js';
+import { CandlesService } from './candles.service.js';
+import { SdkModule } from '../sdk/sdk.module.js';
+
+@Module({
+  imports: [SdkModule],
+  controllers: [CandlesController],
+  providers: [CandlesService],
+})
+export class CandlesModule {}

--- a/src/candles/candles.service.ts
+++ b/src/candles/candles.service.ts
@@ -1,0 +1,50 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import type { ClientSdk as ClientSdkType } from '@quadcode-tech/client-sdk-js';
+
+@Injectable()
+export class CandlesService {
+  private readonly logger = new Logger(CandlesService.name);
+
+  private async findActiveByName(sdk: ClientSdkType, pair: string) {
+    const binaryActives = await sdk
+      .binaryOptions()
+      .then((b) => b.getActives())
+      .catch(() => []);
+
+    return binaryActives.find((a: any) => a.name === pair);
+  }
+
+  async getCandles(sdk: ClientSdkType, pair: string, period: number) {
+    try {
+      const active = await this.findActiveByName(sdk, pair);
+      if (!active) {
+        this.logger.warn(`Active ${pair} not found`);
+        throw new NotFoundException('Ativo não encontrado.');
+      }
+
+      const candles = await sdk.candles();
+      const candlesData = await candles.getCandles(active.id, period);
+
+      const results = candlesData
+        .slice(-250)
+        .map((candle) => ({
+          ...candle,
+          time: new Date((candle.from - 3 * 3600) * 1000).toISOString(),
+        }))
+        .reverse();
+
+      return { coin: active.name, period, results };
+    } catch (error) {
+      this.logger.error(
+        `Error processing candles for pair "${pair}": ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      throw new InternalServerErrorException('Erro ao processar os candles.');
+    }
+  }
+}

--- a/src/candles/dto/get-candles.dto.ts
+++ b/src/candles/dto/get-candles.dto.ts
@@ -1,0 +1,14 @@
+import { SdkCredentialsDto } from '../../sdk/dto/sdk-credentials.dto.js';
+import { IsNotEmpty, IsString, IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetCandlesDto extends SdkCredentialsDto {
+  @IsString({ message: 'pair deve ser uma string' })
+  @IsNotEmpty({ message: 'pair é obrigatório' })
+  pair: string;
+
+  @IsNumber({}, { message: 'period deve ser um número' })
+  @IsNotEmpty({ message: 'period é obrigatório' })
+  @Type(() => Number)
+  period: number;
+}

--- a/src/order/dto/get-history.dto.ts
+++ b/src/order/dto/get-history.dto.ts
@@ -1,10 +1,13 @@
-import { IsEmail, IsNotEmpty } from 'class-validator';
-import { SdkCredentialsDto } from '../../sdk/dto/sdk-credentials.dto.js';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 
 export class GetHistoryDto {
     @IsEmail({}, { message: 'Deve ser um e-mail válido' })
     @IsNotEmpty({ message: 'Email é obrigatório' })
     email: string;
+
+    @IsString({ message: 'collection deve ser uma string' })
+    @IsNotEmpty({ message: 'collection é obrigatório' })
+    collection: string;
 
 
 }

--- a/src/order/dto/get-order.dto.ts
+++ b/src/order/dto/get-order.dto.ts
@@ -17,4 +17,8 @@ export class GetOrderQueryDto {
   @IsString({ message: 'uniqueId deve ser uma string' })
   @IsNotEmpty({ message: 'uniqueId é obrigatório' })
   uniqueId: string;
+
+  @IsString({ message: 'collection deve ser uma string' })
+  @IsNotEmpty({ message: 'collection é obrigatório' })
+  collection: string;
 }

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -19,7 +19,7 @@ export class OrderController {
     this.logger.log(`GET /order - email: ${getOrderDto.email}, orderId: ${getOrderDto.orderId}`);
     const sdk = await this.sdkService.getSdk(getOrderDto.email, getOrderDto.password);
     const orderId = Number(getOrderDto.orderId);
-    const orderDetails = await this.orderService.getOrderDetails(sdk, getOrderDto.email,orderId, getOrderDto.uniqueId);
+    const orderDetails = await this.orderService.getOrderDetails(sdk, getOrderDto.email,orderId, getOrderDto.uniqueId, getOrderDto.collection);
     this.logger.log(`Fetched order details for ${getOrderDto.email} - ${orderId}`);
     return orderDetails;
   }
@@ -27,7 +27,7 @@ export class OrderController {
   @HttpCode(HttpStatus.OK)
   async getOrderHistory(@Query() getOrderDto: GetHistoryDto) {
     this.logger.log(`GET /order/history - email: ${getOrderDto.email}`);
-    const orderHistory = await this.orderService.getOrderHistory(getOrderDto.email);
+    const orderHistory = await this.orderService.getOrderHistory(getOrderDto.email, getOrderDto.collection);
     this.logger.log(`Retrieved order history for ${getOrderDto.email}`);
     return orderHistory;
   }

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -1,16 +1,13 @@
 import { Module } from '@nestjs/common';
 import { SdkModule } from '../sdk/sdk.module.js';
 import { ConfigModule } from '@nestjs/config';
-import { MongooseModule } from '@nestjs/mongoose';
 import { OrderController } from './order.controller.js';
 import { OrderService } from './order.service.js';
-import { OrderResult, OrderResultSchema } from './schemas/order-result.schema.js';
 
 @Module({
   imports: [
     SdkModule,
     ConfigModule,
-    MongooseModule.forFeature([{ name: OrderResult.name, schema: OrderResultSchema }]),
   ],
   controllers: [OrderController],
   providers: [OrderService],

--- a/src/order/schemas/order-result.schema.ts
+++ b/src/order/schemas/order-result.schema.ts
@@ -4,7 +4,7 @@ import { Document } from 'mongoose';
 
 export type OrderResultDocument = OrderResult & Document;
 
-@Schema({ timestamps: true, collection: 'order_results' })
+@Schema({ timestamps: true })
 export class OrderResult {
 
   @Prop({ required: true, index: true })

--- a/src/trading/binary/binary.controller.ts
+++ b/src/trading/binary/binary.controller.ts
@@ -1,0 +1,34 @@
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { BinaryService } from './binary.service.js';
+import { BuyBinaryDto } from './dto/buy-binary.dto.js';
+import { SdkService } from '../../sdk/sdk.service.js';
+
+@Controller('trade/binary')
+export class BinaryController {
+  constructor(
+    private readonly binaryService: BinaryService,
+    private readonly sdkService: SdkService,
+  ) {}
+
+  private readonly logger = new Logger(BinaryController.name);
+
+  @Post('buy')
+  @HttpCode(HttpStatus.CREATED)
+  async buyBinaryOption(@Body() buyBinaryDto: BuyBinaryDto) {
+    this.logger.log(`POST /trade/binary/buy - email: ${buyBinaryDto.email}`);
+    const sdk = await this.sdkService.getSdk(
+      buyBinaryDto.email,
+      buyBinaryDto.password,
+    );
+    const order = await this.binaryService.buyOption(sdk, buyBinaryDto);
+    this.logger.log(`Binary option order placed for ${buyBinaryDto.email}`);
+    return { message: 'Binary option purchase initiated.', order };
+  }
+}

--- a/src/trading/binary/binary.service.ts
+++ b/src/trading/binary/binary.service.ts
@@ -1,0 +1,121 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import type { ClientSdk as ClientSdkType } from '@quadcode-tech/client-sdk-js';
+import { mapTradeDirection } from '../utils/map-direction.util.js';
+import { BuyBinaryDto } from './dto/buy-binary.dto.js';
+import { AccountType as AppAccountType } from '../../shared/enums/account-type.enum.js';
+
+@Injectable()
+export class BinaryService {
+  private readonly logger = new Logger(BinaryService.name);
+
+  async buyOption(
+    sdk: ClientSdkType,
+    buyBinaryDto: BuyBinaryDto,
+  ): Promise<any> {
+    const { assetName, operationValue, direction, account_type, period } =
+      buyBinaryDto;
+
+    this.logger.log(
+      `Attempting to buy binary option for asset "${assetName}", value: ${operationValue}, direction: ${direction}, account: ${account_type}, period: ${period}`,
+    );
+
+    try {
+      const { BalanceType, BinaryOptionsDirection } = await import(
+        '@quadcode-tech/client-sdk-js'
+      );
+
+      const [binaryOptions, balancesInstance] = await Promise.all([
+        sdk.binaryOptions(),
+        sdk.balances(),
+      ]);
+
+      const availableActive = binaryOptions
+        .getActives()
+        .find((item) => !item.isSuspended && item.name === assetName);
+
+      if (!availableActive) {
+        this.logger.warn(
+          `Binary asset "${assetName}" not available for trading.`,
+        );
+        throw new NotFoundException(
+          `Ativo binário "${assetName}" não disponível para trading`,
+        );
+      }
+
+      const instruments = await availableActive.instruments();
+      const availableInstrument = instruments
+        .getAvailableForBuyAt(new Date())
+        .find((instrument) => instrument.period === period);
+
+      if (!availableInstrument) {
+        this.logger.warn(
+          `Instrument (period ${period}s) for binary asset "${assetName}" not found.`,
+        );
+        throw new NotFoundException(
+          `Instrumento (período ${period}s) para o ativo "${assetName}" não encontrado`,
+        );
+      }
+
+      const sdkBalanceType =
+        account_type === AppAccountType.Real
+          ? BalanceType.Real
+          : BalanceType.Demo;
+      const balance = balancesInstance
+        .getBalances()
+        .find((b) => b.type === sdkBalanceType);
+
+      if (!balance) {
+        this.logger.warn(`Balance type "${account_type}" not found.`);
+        throw new NotFoundException(`Saldo "${account_type}" não encontrado`);
+      }
+
+      if (
+        typeof balance.available !== 'number' ||
+        balance.available < operationValue
+      ) {
+        this.logger.warn(
+          `Insufficient balance. Available: ${balance.available}, Needed: ${operationValue}`,
+        );
+        throw new BadRequestException(
+          `Saldo insuficiente para a operação. Disponível: ${balance.available}, Necessário: ${operationValue}`,
+        );
+      }
+
+      const sdkDirection = mapTradeDirection(direction, BinaryOptionsDirection);
+
+      const order = await binaryOptions.buy(
+        availableInstrument,
+        sdkDirection,
+        operationValue,
+        balance,
+      );
+
+      this.logger.log(
+        `Binary option purchased successfully. Order ID (example): ${order.id || 'N/A'}`,
+      );
+      return order;
+    } catch (error) {
+      this.logger.error(
+        `Error buying binary option for asset "${assetName}": ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+      if (
+        error instanceof NotFoundException ||
+        error instanceof BadRequestException
+      ) {
+        throw error;
+      }
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new InternalServerErrorException(
+        `Erro ao comprar opção binária: ${errorMessage}`,
+      );
+    }
+  }
+}

--- a/src/trading/binary/dto/buy-binary.dto.ts
+++ b/src/trading/binary/dto/buy-binary.dto.ts
@@ -1,0 +1,11 @@
+import { BaseTradeDto } from '../../dto/base-trade.dto.js';
+import { IsNumber, IsPositive, IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class BuyBinaryDto extends BaseTradeDto {
+  @IsNumber({}, { message: 'period deve ser um número' })
+  @IsPositive({ message: 'period deve ser um número positivo' })
+  @IsNotEmpty({ message: 'period é obrigatório' })
+  @Type(() => Number)
+  period: number;
+}

--- a/src/trading/trading.module.ts
+++ b/src/trading/trading.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { SdkModule } from '../sdk/sdk.module.js';
 import { DigitalController } from './digital/digital.controller.js';
 import { DigitalService } from './digital/digital.service.js';
+import { BinaryController } from './binary/binary.controller.js';
+import { BinaryService } from './binary/binary.service.js';
 
 
 @Module({
   imports: [SdkModule],
-  controllers: [DigitalController],
-  providers: [DigitalService],
+  controllers: [DigitalController, BinaryController],
+  providers: [DigitalService, BinaryService],
 })
 export class TradingModule {}

--- a/src/trading/utils/map-direction.util.ts
+++ b/src/trading/utils/map-direction.util.ts
@@ -1,8 +1,15 @@
-import { DigitalOptionsDirection, BlitzOptionsDirection } from '@quadcode-tech/client-sdk-js';
+import {
+  DigitalOptionsDirection,
+  BlitzOptionsDirection,
+  BinaryOptionsDirection,
+} from '@quadcode-tech/client-sdk-js';
 import { TradeDirection } from '../../shared/enums/direction.enum.js';
 
 // Generic type for SDK direction enums
-type SdkDirectionEnum = typeof DigitalOptionsDirection | typeof BlitzOptionsDirection;
+type SdkDirectionEnum =
+  | typeof DigitalOptionsDirection
+  | typeof BlitzOptionsDirection
+  | typeof BinaryOptionsDirection;
 
 export function mapTradeDirection<T extends SdkDirectionEnum>(
   direction: TradeDirection,


### PR DESCRIPTION
## Summary
- add /candles endpoint to fetch candles by asset and period
- support binary option trades
- share direction mapping across digital and binary options
- fetch candles only for binary assets
- allow specifying database collection for order results so operations target requested collection

## Testing
- `npm test` (fails: Cannot find module './app.controller.js')

------
https://chatgpt.com/codex/tasks/task_e_6895fee1c2a08331860ad0e693889696